### PR TITLE
Stop pinning GitHub actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag vtintillier/docker-swift:4.1.0
+      run: docker build . --file Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,19 +13,19 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@12cce9efe0d49980455aaaca9b071c0befcdd702
+        uses: docker/metadata-action@v4
         with:
           images: vtintillier/docker-swift
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@eeab5ede1605119641cb6666653a2a9e2c7539ec
+        uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: ./Dockerfile
           format: sarif


### PR DESCRIPTION
To avoid too much noise with Renovate updates.

Also simplify docker build.